### PR TITLE
Use PTY.check to force raise of PTY::ChildExited

### DIFF
--- a/lib/greenletters.rb
+++ b/lib/greenletters.rb
@@ -516,6 +516,7 @@ module Greenletters
       # Soon we should get a PTY::ChildExited
       while running? || ended?
         @logger.debug "waiting for child #{@pid} to die"
+        PTY.check(@pid, true) if PTY.respond_to? :check
         sleep 0.1
       end
     end


### PR DESCRIPTION
```
PTY no longer raises PTY::ChildExited on 1.9.2 unless called by
PTY.check with raise = true
```

The example for greenletters doesn't work on Ruby >= 1.9.2. It just hangs on `adv.wait_for(:exit)`. I tracked this down to an API change in ruby's PTY library. PTY doesn't raise PTY::ChildExisted unless explicitly asked by the `check` method.  This pull request should work with at least ruby >= 1.8.7.
